### PR TITLE
bugfix: merge location configration

### DIFF
--- a/src/ngx_http_redis2_module.c
+++ b/src/ngx_http_redis2_module.c
@@ -229,6 +229,15 @@ ngx_http_redis2_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->complex_query = prev->complex_query;
     }
 
+    if (conf->queries == NULL) {
+        conf->queries = prev->queries;
+    }
+
+    if (conf->literal_query.data == NULL) {
+        conf->literal_query.data = prev->literal_query.data;
+        conf->literal_query.len = prev->literal_query.len;
+    }
+
     return NGX_CONF_OK;
 }
 


### PR DESCRIPTION
Function merge_loc_conf doesn't merge parameters 'queries' and 'literal_query', so I sometimes get error 'no redis2 query specified or the query is empty'.

For example:

```
    location /redis {
            set $key 'default';
            if ($uri ~ "(special.*)") {
                    set $key $1;
            }
            redis2_query lrange $key 0 -1;
            redis2_pass 127.0.0.1:6379;
    }
```

You will get HTTP/500 if you send query /redis/special_001. For query '/redis/test' everything work fine.
