### PR TITLE
Fixes build issue with Nginx 1.11.6

### DIFF
--- a/src/ngx_http_redis2_util.c
+++ b/src/ngx_http_redis2_util.c
@@ -77,6 +77,7 @@ ngx_http_redis2_upstream_add(ngx_http_request_t *r, ngx_url_t *url)
             continue;
         }
 
+#if (nginx_version < 1011006)
         if (uscfp[i]->default_port
             && url->default_port
             && uscfp[i]->default_port != url->default_port)
@@ -84,6 +85,7 @@ ngx_http_redis2_upstream_add(ngx_http_request_t *r, ngx_url_t *url)
             dd("upstream_add: default_port not match");
             continue;
         }
+#endif
 
         return uscfp[i];
     }


### PR DESCRIPTION
This module doesn't compile on 1.11.6 with the following error:

```c
	-o objs/addon/src/ngx_http_redis2_util.o \
	modules/redis2-nginx-module/src/ngx_http_redis2_util.c
modules/redis2-nginx-module/src/ngx_http_redis2_util.c: In function 'ngx_http_redis2_upstream_add':
modules/redis2-nginx-module/src/ngx_http_redis2_util.c:80:21: error: 'ngx_http_upstream_srv_conf_t {aka struct ngx_http_upstream_srv_conf_s}' has no member named 'default_port'
         if (uscfp[i]->default_port
                     ^
modules/redis2-nginx-module/src/ngx_http_redis2_util.c:82:24: error: 'ngx_http_upstream_srv_conf_t {aka struct ngx_http_upstream_srv_conf_s}' has no member named 'default_port'
             && uscfp[i]->default_port != url->default_port)
                        ^
objs/Makefile:1714: recipe for target 'objs/addon/src/ngx_http_redis2_util.o' failed
make[2]: *** [objs/addon/src/ngx_http_redis2_util.o] Error 1
```

(See https://travis-ci.org/charlesportwoodii/nginx-build/jobs/176088192 for a failing build). #41 also has some specific details

`default_port` is no longer defined in `ngx_http_upstream_srv_conf_s` as of 1.11.6. This simplistic patch excludes use of the `default_port` in 1.11.6 and higher. This is a pretty naive approach to this problem, just wanted to post _a_ solution since y'all are probably pretty busy today. 