### PR TITLE
[WIP] Support chunked_transfer_encoding configuration

### DIFF
--- a/src/ngx_http_redis2_handler.c
+++ b/src/ngx_http_redis2_handler.c
@@ -231,6 +231,7 @@ ngx_http_redis2_process_header(ngx_http_request_t *r)
     ngx_buf_t                   *b;
     u_char                       chr;
     ngx_str_t                    buf;
+    ngx_http_core_loc_conf_t    *clcf;
 
     u = r->upstream;
     b = &u->buffer;
@@ -266,6 +267,12 @@ ngx_http_redis2_process_header(ngx_http_request_t *r)
             return NGX_HTTP_UPSTREAM_INVALID_HEADER;
     }
 
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+    
+    if (!clcf->chunked_transfer_encoding) {
+        u->headers_in.content_length_n = b->last - b->pos;
+    }
+    
     u->headers_in.status_n = NGX_HTTP_OK;
     u->state->status = NGX_HTTP_OK;
 


### PR DESCRIPTION
Hi, @agentzh , thank you for your great redis module.

I support `chunked_transfer_encoding off`.

## chunked_transfer_encoding `off`

- configuration

```nginx
        location /redis {
            chunked_transfer_encoding off;
            redis2_pass 127.0.0.1:6379;
            redis2_query get "nginx";
        }
```

- nginx reply

```
$ curl http://127.0.0.1:58080/redis  -v
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 58080 (#0)
> GET /redis HTTP/1.1
> Host: 127.0.0.1:58080
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.15.0
< Date: Mon, 11 Jun 2018 09:50:59 GMT
< Content-Type: text/plain
< Content-Length: 11
< Connection: keep-alive
< 
$5
hello
* Connection #0 to host 127.0.0.1 left intact
```

## chunked_transfer_encoding on by default

- configuration

```nginx
        location /redis {
            redis2_pass 127.0.0.1:6379;
            redis2_query get "nginx";
        }
```

- nginx reply

```
$ curl http://127.0.0.1:58080/redis  -v
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 58080 (#0)
> GET /redis HTTP/1.1
> Host: 127.0.0.1:58080
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.15.0
< Date: Mon, 11 Jun 2018 09:52:05 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
< 
$5
hello
* Connection #0 to host 127.0.0.1 left intact
```
